### PR TITLE
Fix flow declaration file

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,32 +1,30 @@
 /* @flow strict */
 
-declare module '@github/remote-form' {
-  type Kicker = {
-    text: () => Promise<SimpleResponse>,
-    json: () => Promise<SimpleResponse>,
-    html: () => Promise<SimpleResponse>
-  }
-
-  type SimpleRequest = {
-    method: string,
-    url: string,
-    body: ?FormData,
-    headers: Headers
-  }
-
-  export type SimpleResponse = {
-    url: string,
-    status: number,
-    statusText: ?string,
-    headers: Headers,
-    text: string,
-    json: {[string]: any},
-    html: DocumentFragment
-  }
-  export type RemoteFormHandler = (form: HTMLFormElement, kicker: Kicker, req: SimpleRequest) => void | Promise<void>;
-
-  declare export function afterRemote(fn: (form: HTMLFormElement) => mixed): void;
-  declare export function beforeRemote(fn: (form: HTMLFormElement) => mixed): void;
-  declare export function remoteForm(selector: string, fn: RemoteFormHandler): void;
-  declare export function remoteUninstall(selector: string, fn: RemoteFormHandler): void;
+type Kicker = {
+  text: () => Promise<SimpleResponse>,
+  json: () => Promise<SimpleResponse>,
+  html: () => Promise<SimpleResponse>
 }
+
+type SimpleRequest = {
+  method: string,
+  url: string,
+  body: ?FormData,
+  headers: Headers
+}
+
+export type SimpleResponse = {
+  url: string,
+  status: number,
+  statusText: ?string,
+  headers: Headers,
+  text: string,
+  json: {[string]: any},
+  html: DocumentFragment
+}
+export type RemoteFormHandler = (form: HTMLFormElement, kicker: Kicker, req: SimpleRequest) => void | Promise<void>;
+
+declare export function afterRemote(fn: (form: HTMLFormElement) => mixed): void;
+declare export function beforeRemote(fn: (form: HTMLFormElement) => mixed): void;
+declare export function remoteForm(selector: string, fn: RemoteFormHandler): void;
+declare export function remoteUninstall(selector: string, fn: RemoteFormHandler): void;


### PR DESCRIPTION
Since we aren't define a [third-party library in a application code-base](https://flow.org/en/docs/libdefs/creation/#toc-declaring-a-module) we don't need to (and shouldn't) define a module.

The flow syntax also doesn't require a `declare` keyword on types. Not sure where that distinction is documented 😬 