### PR TITLE
add `Promise<void>` to handlers return types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export type SimpleResponse = {
 }
 
 export type RemoteFormHandler = (form: HTMLFormElement, kicker: Kicker, req: SimpleRequest) => void | Promise<void>;
-export function afterRemote(fn: (form: HTMLFormElement) => void): void;
-export function beforeRemote(fn: (form: HTMLFormElement) => void): void;
+export function afterRemote(fn: (form: HTMLFormElement) => void | Promise<void>): void;
+export function beforeRemote(fn: (form: HTMLFormElement) => void | Promise<void>): void;
 export function remoteForm(selector: string, fn: RemoteFormHandler): void;
 export function remoteUninstall(selector: string, fn: RemoteFormHandler): void;

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -24,7 +24,7 @@ export type SimpleResponse = {
 }
 export type RemoteFormHandler = (form: HTMLFormElement, kicker: Kicker, req: SimpleRequest) => void | Promise<void>;
 
-declare export function afterRemote(fn: (form: HTMLFormElement) => void): void;
-declare export function beforeRemote(fn: (form: HTMLFormElement) => void): void;
+declare export function afterRemote(fn: (form: HTMLFormElement) => void | Promise<void>): void;
+declare export function beforeRemote(fn: (form: HTMLFormElement) => void | Promise<void>): void;
 declare export function remoteForm(selector: string, fn: RemoteFormHandler): void;
 declare export function remoteUninstall(selector: string, fn: RemoteFormHandler): void;


### PR DESCRIPTION
JavaScript is funny 😄 

Since we aren't using the `mixed` return type after #8 but rather `void` we need to also include the `Promise<void>` return type if we want any of our handler callbacks to be `await/async`.