### PR TITLE
Use native FormData.entries if it exists

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <script src="https://unpkg.com/selector-set@latest"></script>
-  <script src="https://unpkg.com/form-data-entries@latest"></script>
   <script src="https://unpkg.com/@github/remote-form@latest/dist/index.umd.js"></script>
   <!-- <script src="../dist/index.umd.js"></script> -->
   <title>remote-form demo</title>

--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,9 @@ function parseHTML(document: Document, html: string): DocumentFragment {
 
 function serialize(form: HTMLFormElement): string {
   const params = new URLSearchParams()
-  for (const [name, value] of formDataEntries(form)) {
-    params.append(name, value)
+  const entries = 'entries' in FormData.prototype ? new FormData(form).entries() : formDataEntries(form)
+  for (const [name, value] of [...entries]) {
+    params.append(name, value.toString())
   }
   return params.toString()
 }


### PR DESCRIPTION
Browsers with `FormData.entries` shouldn't have to import the ponyfill.