### PR TITLE
Skip events that already have default prevented

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ function getMatches(el: HTMLElement): RemoteFormHandler[] {
 }
 
 function handleSubmit(event: Event) {
-  if (!(event.target instanceof HTMLFormElement)) {
+  if (!(event.target instanceof HTMLFormElement) || event.defaultPrevented) {
     return
   }
   const form = event.target

--- a/test/test.js
+++ b/test/test.js
@@ -139,4 +139,20 @@ describe('remoteForm', function () {
     button.form.action += '?a=b'
     button.click()
   })
+
+  it('does not submit the request if default is already prevented', function () {
+    // prevent default before this event reaches the remote-form listener
+    const defaultPreventHandler = event => event.preventDefault()
+    document.addEventListener('submit', defaultPreventHandler, {capture: true})
+
+    let handlerCalled = false
+    remoteForm('.my-remote-form', async function () {
+      handlerCalled = true
+    })
+
+    document.querySelector('button[type=submit]').click()
+
+    assert.isFalse(handlerCalled)
+    document.removeEventListener('submit', defaultPreventHandler, {capture: true})
+  })
 })


### PR DESCRIPTION
There may be scenarios where you want to do client-side validation or have some other specialty handler for a form.  In these scenarios, it would be nice to have an escape hatch that prevents `remoteForm` from handling the event.

There are also some rare (but possible) edge cases with code bundlers where an app could double load this module and execute it twice, creating two registered listeners for form `submit` events.  In this scenario, both instances of `remoteForm` would trigger their handlers and send the fetch request, causing a double submission.

In both cases, a solution is to check if the event has already been handled by checking `event.defaultPrevented`.  This allows custom handlers to prevent further action with the event, and handles the double load scenario because we already call `preventDefault` within `remoteForm`.

This should fix an outstanding issue in github/github where comment creation and other actions can be executed twice.