### PR TITLE
Prevent errors if remoteForm is run in an SSR environment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,10 @@ export function beforeRemote(fn: Handler): void {
 export function remoteForm(selector: string, fn: RemoteFormHandler): void {
   if (!formHandlers) {
     formHandlers = new Map<string, RemoteFormHandler[]>()
-    document.addEventListener('submit', handleSubmit)
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('submit', handleSubmit)
+    }
   }
   const handlers = formHandlers.get(selector) || []
   formHandlers.set(selector, [...handlers, fn])


### PR DESCRIPTION
We have some code being run in an SSR environment (where `document` is not defined) which breaks currently. This adds a safety check to only add event listeners if `document` is actually defined.