### PR TITLE
Install `remoteForm` directly onto passed element.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -45,6 +45,11 @@ describe('remoteForm', function () {
     document.querySelector('button[type=submit]').click()
   })
 
+  it('installs remoteForm on form reference', function (done) {
+    remoteForm(htmlForm, async () => done())
+    document.querySelector('button[type=submit]').click()
+  })
+
   it('server failure scenario', function (done) {
     htmlForm.action = 'server-error'
 


### PR DESCRIPTION
remoteForm can install itself onto any element that matches passed selector. In some cases, you might want to install remoteForm onto a specific form element without having to assign this form an `id` just to make it selectable.

This change allows passing a `HTMLFormElement` reference to remoteForm directly.

Let me know what you think and if that change fits into the overall design of remoteForm!