### PR TITLE
feat: include submitter info.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -164,4 +164,15 @@ describe('remoteForm', function () {
     assert.isFalse(handlerCalled)
     document.removeEventListener('submit', defaultPreventHandler, {capture: true})
   })
+
+  it('overwrites form method with buttons formmethod', function (done) {
+    remoteForm(htmlForm, async (form, wants, req) => {
+      assert.equal(req.method.toUpperCase(), 'GET')
+      done()
+    })
+
+    const button = document.querySelector('button[type=submit]')
+    button.formMethod = 'get'
+    button.click()
+  })
 })


### PR DESCRIPTION
Buttons allow you to overwrite a forms `method` with the `formmethod` attribute. `buildRequest` now incorporates submitter info when determining the request method. `SubmitEvent` interface is now generally supported.
 
I also browsed https://github.com/github/remote-form/pull/16. In comparison to then, `submitter` parameter to `FormData` is now available. Do you reconsider merging https://github.com/github/remote-form/pull/16 or any PR that would implement it? :-)