### PR TITLE
Fix publish permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,6 @@ permissions:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
I added provenance support in #42, which requires `id-token: write` permissions. I missed the fact that there was already a `permissions` block within the job definition, which overrode my top level permissions.